### PR TITLE
Strip whitespace from SongSearchItem tags on parsing

### DIFF
--- a/usdx_scraper.py
+++ b/usdx_scraper.py
@@ -66,14 +66,23 @@ class SongSearchItem:
             return self
         elif "-" in tag_list[0]:
             s = tag_list[0].split("-")
-            self.artist_tag_tuple = tuple(s[:-1])
-            self.name_tag_tuple = tuple(s[-1:])
+            
+            artist_tag_tuple = tuple(s[:-1])
+            self.artist_tag_tuple = self.strip(artist_tag_tuple)
+
+            name_tag_tuple = tuple(s[-1:])
+            self.name_tag_tuple = self.strip(name_tag_tuple)
+
             return self
         else:
             return self
 
     def get_list(self) -> list:
         return list(self.name_tag_tuple)+list(self.artist_tag_tuple)
+    
+    @staticmethod
+    def strip(tags):
+        return tuple(tag.strip() for tag in tags)
 
 def raise_error(err_massage:str):
     print(err_massage)


### PR DESCRIPTION
I've added a utility to strip leading and trailing whitespace from `SongSearchItem` tag-tuples. This change was necessary to properly handle input files formatted like:

```txt
Artist - Song Name
```

Previously, such input would result in a `SongSearchItem` with:

- Artist: `Artist `  
- Song Name: ` Song Name`

Note the unintended whitespace in both fields. With this update, the values are now correctly parsed as:

- Artist: `Artist`  
- Song Name: `Song Name`