### PR TITLE
Replace `pytube` with `yt-dlp` and add MP4 download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ options:
   -fa, --findAll        Set to search for ALL songs matching the inputs. Otherwise the parser will try to find exactly one song per search entry
   -o OUTPUT, --output OUTPUT
                         The output directory where all songs and their text files should be saved
+  -ft FILETYPE, --filetype FILETYPE
+                        The file type to be used for the downloaded songs. Either MP3 or MP4. Default is MP3
+  -mvr MAXVIDRES, --maxVidRes MAXVIDRES
+                        Maximum video resolution to be used for the downloaded songs. Default is 480p. Only used if filetype is MP4
   -sid SPOTIFYCLIENTID, --spotifyClientId SPOTIFYCLIENTID
                         The Client ID to be used for accessing Spotifies Web API
   -ssc SPOTIFYCLIENTSECRET, --spotifyClientSecret SPOTIFYCLIENTSECRET

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 spotipy==2.22.1
 beautifulsoup4==4.11.1
 youtube-search-python==1.6.6
-pytube==12.1.2
+yt-dlp==2025.3.31
 html5lib==1.1


### PR DESCRIPTION
While running the scraper, `pytube` consistently threw HTTP 400 errors. To resolve this, I replaced it with the more robust `yt-dlp` package.

Additionally, I’ve introduced an option to download `.mp4` video files instead of `.mp3` audio files.